### PR TITLE
Add support for custom authorization servers

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -50,9 +50,17 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
+    protected function getAuthServerId()
+    {
+        return $this->getConfig('auth_server_id', 'default');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public static function additionalConfigKeys()
     {
-        return ['base_url'];
+        return ['base_url', 'auth_server_id'];
     }
 
     /**
@@ -60,7 +68,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getOktaUrl().'/oauth2/v1/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/authorize', $state);
     }
 
     /**
@@ -68,7 +76,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return $this->getOktaUrl().'/oauth2/v1/token';
+        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/token';
     }
 
     /**
@@ -76,7 +84,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getOktaUrl().'/oauth2/v1/userinfo', [
+        $response = $this->getHttpClient()->get($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],


### PR DESCRIPTION
Okta allows different authorization servers to be used as documented [here](https://help.okta.com/en/prev/Content/Topics/Security/API_Access.htm?cshid=API_Access#API_Access). This can be useful for e.g. staging/test servers. By default an out of the box authorization server is provided by Okta simply labelled `default`, with additional authorization servers labelled with a randomly generated string. If the user adds an `ENV` variable `OKTA_AUTH_SERVER_ID` then this will be used, otherwise the default of `default` will be used.