### PR TITLE
fix(Token): token URL does not need slash after getAuthServerId

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -81,7 +81,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/token';
+        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/token';
     }
 
     /**


### PR DESCRIPTION
The following error revealed a double slash in the token url. (I don't suspect it broke anything... anymore)

![image](https://user-images.githubusercontent.com/54292758/111229386-6f693600-85ab-11eb-9c26-36daaba29484.png)

This should remove that double slash.