### PR TITLE
Fix `getRefreshTokenResponse()` signature

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -130,9 +130,9 @@ class Provider extends AbstractProvider
 
     /**
      * @param  string  $refreshToken
-     * @return array
+     * @return array|null
      */
-    public function getRefreshTokenResponse(string $refreshToken)
+    public function getRefreshTokenResponse($refreshToken)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::AUTH        => [$this->clientId, $this->clientSecret],


### PR DESCRIPTION
Fix signature for `Provider@getRefreshTokenResponse()` due to the same method name (with a different signature) being introduced by https://github.com/laravel/socialite/pull/675